### PR TITLE
Add rich terminal output formatting to CLI

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -5,6 +5,7 @@ pub fn build(b: *std.Build) void {
     const optimize = b.standardOptimizeOption(.{});
 
     const webzocket = b.dependency("webzocket", .{}).module("webzocket");
+    const rich_zig = b.dependency("rich_zig", .{}).module("rich_zig");
 
     const mod = b.addModule("zunk", .{
         .root_source_file = b.path("src/root.zig"),
@@ -19,6 +20,7 @@ pub fn build(b: *std.Build) void {
             .imports = &.{
                 .{ .name = "zunk", .module = mod },
                 .{ .name = "webzocket", .module = webzocket },
+                .{ .name = "rich_zig", .module = rich_zig },
             },
         }),
     });

--- a/src/gen/serve.zig
+++ b/src/gen/serve.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const webzocket = @import("webzocket");
+const rich = @import("rich_zig");
 const native_os = @import("builtin").os.tag;
 const windows = std.os.windows;
 
@@ -44,42 +45,56 @@ const WsRegistry = struct {
     }
 };
 
-pub fn serve(allocator: std.mem.Allocator, root_dir_path: []const u8, port: u16, autoreload: bool) !void {
+pub fn serve(allocator: std.mem.Allocator, root_dir_path: []const u8, port: u16, autoreload: bool, console: *rich.Console) !void {
     var root_dir = try std.fs.cwd().openDir(root_dir_path, .{});
     defer root_dir.close();
 
     var ws_reg = WsRegistry{};
 
     if (autoreload) {
-        const watcher = std.Thread.spawn(.{}, watcherThread, .{ root_dir_path, &ws_reg });
+        const watcher = std.Thread.spawn(.{}, watcherThread, .{ root_dir_path, &ws_reg, console });
         if (watcher) |t| t.detach() else |err| {
-            std.debug.print("warning: could not start file watcher: {}\n", .{err});
+            var buf: [256]u8 = undefined;
+            const msg = std.fmt.bufPrint(&buf, "warning: could not start file watcher: {}", .{err}) catch "warning: could not start file watcher";
+            console.printStyled(msg, rich.Style.empty.foreground(rich.Color.yellow)) catch {};
         }
     }
 
     const addr = std.net.Address.initIp4(.{ 127, 0, 0, 1 }, port);
     var server = addr.listen(.{ .reuse_address = true }) catch |err| {
         if (err == error.AddressInUse) {
-            std.debug.print("error: port {d} is already in use\n", .{port});
+            var buf: [128]u8 = undefined;
+            const msg = std.fmt.bufPrint(&buf, "error: port {d} is already in use", .{port}) catch "error: port is already in use";
+            console.printStyled(msg, rich.Style.empty.bold().foreground(rich.Color.red)) catch {};
         }
         return err;
     };
     defer server.deinit();
 
-    const reload_note: []const u8 = if (autoreload) " (live reload enabled)" else "";
-    std.debug.print("Serving on http://127.0.0.1:{d}/{s}\nPress Ctrl+C to stop.\n", .{ port, reload_note });
+    const reload_note: []const u8 = if (autoreload) "\nlive reload enabled" else "";
+    var banner_buf: [256]u8 = undefined;
+    const banner_content = std.fmt.bufPrint(&banner_buf, "http://127.0.0.1:{d}{s}", .{ port, reload_note }) catch "localhost";
+
+    const banner = rich.Panel.fromText(allocator, banner_content)
+        .withTitle("zunk dev server")
+        .withBorderStyle(rich.Style.empty.foreground(rich.Color.green));
+    try console.printRenderable(banner);
+    try console.print("[dim]Press Ctrl+C to stop.[/]");
+    try console.print("");
 
     while (true) {
         const conn = server.accept() catch |err| {
-            std.debug.print("accept error: {}\n", .{err});
+            var buf: [128]u8 = undefined;
+            const msg = std.fmt.bufPrint(&buf, "accept error: {}", .{err}) catch "accept error";
+            console.printStyled(msg, rich.Style.empty.foreground(rich.Color.red)) catch {};
             continue;
         };
-        const thread = std.Thread.spawn(.{}, connectionThread, .{ allocator, conn.stream, root_dir, &ws_reg, autoreload });
+        const thread = std.Thread.spawn(.{}, connectionThread, .{ allocator, conn.stream, root_dir, &ws_reg, autoreload, console });
         if (thread) |t| t.detach() else |_| conn.stream.close();
     }
 }
 
-fn connectionThread(allocator: std.mem.Allocator, stream: std.net.Stream, root_dir: std.fs.Dir, ws_reg: *WsRegistry, autoreload: bool) void {
+fn connectionThread(allocator: std.mem.Allocator, stream: std.net.Stream, root_dir: std.fs.Dir, ws_reg: *WsRegistry, autoreload: bool, console: *rich.Console) void {
     defer stream.close();
 
     var buf: [4096]u8 = undefined;
@@ -95,12 +110,14 @@ fn connectionThread(allocator: std.mem.Allocator, stream: std.net.Stream, root_d
         return;
     }
 
-    handleHttpRequest(allocator, stream, root_dir, request) catch |err| {
-        std.debug.print("request error: {}\n", .{err});
+    handleHttpRequest(allocator, stream, root_dir, request, console) catch |err| {
+        var err_buf: [128]u8 = undefined;
+        const msg = std.fmt.bufPrint(&err_buf, "request error: {}", .{err}) catch "request error";
+        console.printStyled(msg, rich.Style.empty.foreground(rich.Color.red)) catch {};
     };
 }
 
-fn handleHttpRequest(allocator: std.mem.Allocator, stream: std.net.Stream, root_dir: std.fs.Dir, request: []const u8) !void {
+fn handleHttpRequest(allocator: std.mem.Allocator, stream: std.net.Stream, root_dir: std.fs.Dir, request: []const u8, console: *rich.Console) !void {
     const path = parsePath(request) orelse return;
 
     if (std.mem.indexOf(u8, path, "..") != null) {
@@ -116,7 +133,10 @@ fn handleHttpRequest(allocator: std.mem.Allocator, stream: std.net.Stream, root_
     };
     defer allocator.free(file_data);
 
-    std.debug.print("{s} -> {s}\n", .{ path, rel_path });
+    var log_buf: [512]u8 = undefined;
+    const log_msg = std.fmt.bufPrint(&log_buf, "{s} -> {s}", .{ path, rel_path }) catch return;
+    console.printStyled(log_msg, rich.Style.empty.dim()) catch {};
+
     try sendResponse(stream, "200 OK", mimeType(rel_path), file_data);
 }
 
@@ -161,13 +181,13 @@ fn wsReadLoop(handle: Handle) void {
     }
 }
 
-fn watcherThread(root_dir_path: []const u8, ws_reg: *WsRegistry) void {
+fn watcherThread(root_dir_path: []const u8, ws_reg: *WsRegistry, console: *rich.Console) void {
     var last_fingerprint: i128 = 0;
     _ = pollDirChanged(root_dir_path, &last_fingerprint);
     while (true) {
         std.Thread.sleep(500 * std.time.ns_per_ms);
         if (pollDirChanged(root_dir_path, &last_fingerprint)) {
-            std.debug.print("[reload] dist/ changed, notifying browsers\n", .{});
+            console.printStyled("reload: dist/ changed, notifying browsers", rich.Style.empty.bold().foreground(rich.Color.yellow)) catch {};
             ws_reg.broadcast("reload");
         }
     }

--- a/src/main.zig
+++ b/src/main.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const rich = @import("rich_zig");
 
 const wa = @import("gen/wasm_analyze.zig");
 const js_gen = @import("gen/js_gen.zig");
@@ -7,46 +8,52 @@ const dev_server = @import("gen/serve.zig");
 pub fn main() !void {
     const allocator = std.heap.page_allocator;
 
+    var console = rich.Console.init(allocator);
+    defer console.deinit();
+
     const args = try std.process.argsAlloc(allocator);
     defer std.process.argsFree(allocator, args);
 
     if (args.len < 2) {
-        printUsage();
+        try printUsage(&console);
         return;
     }
 
     const cmd = args[1];
 
     if (std.mem.eql(u8, cmd, "build")) {
-        try buildCommand(allocator, args[2..], false);
+        try buildCommand(allocator, args[2..], false, &console);
     } else if (std.mem.eql(u8, cmd, "run")) {
-        try buildCommand(allocator, args[2..], true);
+        try buildCommand(allocator, args[2..], true, &console);
     } else if (std.mem.eql(u8, cmd, "help") or std.mem.eql(u8, cmd, "--help") or std.mem.eql(u8, cmd, "-h")) {
-        printUsage();
+        try printUsage(&console);
     } else if (std.mem.eql(u8, cmd, "version") or std.mem.eql(u8, cmd, "--version")) {
-        std.debug.print("zunk 0.1.0\n", .{});
+        try console.print("[bold cyan]zunk[/] 0.1.0");
     } else {
-        std.debug.print("unknown command: {s}\n", .{cmd});
-        printUsage();
+        var buf: [256]u8 = undefined;
+        const msg = std.fmt.bufPrint(&buf, "unknown command: {s}", .{cmd}) catch "unknown command";
+        try console.printStyled(msg, rich.Style.empty.bold().foreground(rich.Color.red));
+        try printUsage(&console);
     }
 }
 
-fn printUsage() void {
-    std.debug.print(
-        \\Usage: zunk <command> [options]
-        \\
-        \\Commands:
-        \\  build    Compile .wasm, analyze, generate JS + HTML
-        \\  run      Build + serve on localhost
-        \\  help     Show this help
-        \\  version  Show version
-        \\
-        \\Options:
-        \\  --wasm <path>         Path to a pre-compiled .wasm file
-        \\  --output-dir <path>   Output directory (default: dist)
-        \\  --port <num>          Server port for 'run' (default: 8080)
-        \\
-    , .{});
+fn printUsage(console: *rich.Console) !void {
+    try console.print("");
+    try console.print("  [bold cyan]zunk[/] -- build tool for Zig WASM applications");
+    try console.print("");
+    try console.print("  [bold]Usage:[/] zunk <command> \\[options]");
+    try console.print("");
+    try console.print("  [bold]Commands:[/]");
+    try console.print("    [green]build[/]      Compile .wasm, analyze, generate JS + HTML");
+    try console.print("    [green]run[/]        Build + serve on localhost");
+    try console.print("    [green]help[/]       Show this help");
+    try console.print("    [green]version[/]    Show version");
+    try console.print("");
+    try console.print("  [bold]Options:[/]");
+    try console.print("    [yellow]--wasm[/] <path>         Path to a pre-compiled .wasm file");
+    try console.print("    [yellow]--output-dir[/] <path>   Output directory (default: dist)");
+    try console.print("    [yellow]--port[/] <num>          Server port for 'run' (default: 8080)");
+    try console.print("");
 }
 
 const BuildArgs = struct {
@@ -73,15 +80,17 @@ fn parseBuildArgs(args: []const []const u8) BuildArgs {
     return result;
 }
 
-fn buildCommand(allocator: std.mem.Allocator, args: []const []const u8, do_serve: bool) !void {
+fn buildCommand(allocator: std.mem.Allocator, args: []const []const u8, do_serve: bool, console: *rich.Console) !void {
     const parsed = parseBuildArgs(args);
     const wasm_path = parsed.wasm_path orelse {
-        std.debug.print("error: --wasm <path> required (auto-compile not yet implemented)\n", .{});
+        try console.print("[bold red]error:[/] --wasm <path> required (auto-compile not yet implemented)");
         return;
     };
 
     const wasm = std.fs.cwd().readFileAlloc(allocator, wasm_path, 10 * 1024 * 1024) catch |err| {
-        std.debug.print("error: could not read '{s}': {}\n", .{ wasm_path, err });
+        var buf: [512]u8 = undefined;
+        const msg = std.fmt.bufPrint(&buf, "error: could not read '{s}': {}", .{ wasm_path, err }) catch "error: could not read wasm file";
+        try console.printStyled(msg, rich.Style.empty.foreground(rich.Color.red));
         return;
     };
     defer allocator.free(wasm);
@@ -106,10 +115,19 @@ fn buildCommand(allocator: std.mem.Allocator, args: []const []const u8, do_serve
     try out_dir.writeFile(.{ .sub_path = "app.js", .data = result.js });
     try out_dir.writeFile(.{ .sub_path = wasm_basename, .data = wasm });
 
-    std.debug.print("{s}\nBuild complete: {s}/\n", .{ result.report, parsed.output_dir });
+    try console.print("");
+    const report_panel = rich.Panel.fromText(allocator, result.report)
+        .withTitle("Build Report")
+        .withBorderStyle(rich.Style.empty.foreground(rich.Color.cyan));
+    try console.printRenderable(report_panel);
+
+    var complete_buf: [256]u8 = undefined;
+    const complete_msg = std.fmt.bufPrint(&complete_buf, "Build complete: {s}/", .{parsed.output_dir}) catch "Build complete";
+    try console.printStyled(complete_msg, rich.Style.empty.bold().foreground(rich.Color.green));
 
     if (do_serve) {
-        try dev_server.serve(allocator, parsed.output_dir, parsed.port, true);
+        try console.print("");
+        try dev_server.serve(allocator, parsed.output_dir, parsed.port, true, console);
     }
 }
 


### PR DESCRIPTION
## Summary
Integrate the `rich_zig` library to replace plain text debug output with styled, formatted terminal output throughout the CLI application. This improves user experience with colored text, panels, and better visual hierarchy.

## Key Changes
- **Main CLI (`src/main.zig`)**:
  - Initialize `rich.Console` for all output operations
  - Replace `std.debug.print()` calls with `console.print()` and `console.printStyled()`
  - Enhance `printUsage()` function with colored command/option names and formatted layout
  - Add styled error messages with red foreground for unknown commands
  - Display version with cyan styling
  - Pass console reference to `buildCommand()` for consistent output

- **Build Command (`src/main.zig`)**:
  - Replace error messages with styled red text
  - Wrap build report in a `rich.Panel` with cyan border and title
  - Display completion message in bold green
  - Pass console to dev server for coordinated output

- **Dev Server (`src/gen/serve.zig`)**:
  - Add console parameter to `serve()`, `connectionThread()`, `handleHttpRequest()`, and `watcherThread()`
  - Replace all debug prints with styled console output
  - Display server banner in a green-bordered panel
  - Style file access logs with dim text
  - Style warnings in yellow and errors in red
  - Style file watcher notifications in bold yellow

- **Build Configuration (`build.zig`)**:
  - Add `rich_zig` dependency module to executable

## Implementation Details
- All console operations are properly error-handled with `try` statements
- Buffer-based string formatting used for dynamic messages to avoid allocations where possible
- Consistent styling applied: commands/paths in green, options in yellow, errors in red, warnings in yellow
- Maintains backward compatibility by gracefully handling console errors in background threads

https://claude.ai/code/session_01JQVghHAS3RLQEbEqmfZijL