### PR TITLE
Add bridge.js package convention for dep-provided JS

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,24 @@ extern "env" fn my_webrtc_connect(url_ptr: [*]const u8, url_len: u32) i32;
 ```
 Ship a `bridge.js` alongside your project or library. Zunk merges it into the generated output.
 
+#### Shipping a `bridge.js` in a Zig library
+
+A Zig package that exposes its own browser-side JS places a `bridge.js` at the package root (next to `build.zig.zon`). Consumers opt in via `zunk.installApp`:
+
+```zig
+// consumer's build.zig
+const zunk = b.dependency("zunk", .{ .target = wasm_target, .optimize = optimize });
+const teak = b.dependency("teak", .{ .target = wasm_target, .optimize = optimize });
+
+@import("zunk").installApp(b, zunk, exe, .{
+    .bridge_deps = &.{ teak },  // merges teak's bridge.js automatically
+});
+```
+
+**Merge order.** Dep-provided chunks are emitted first, in the order listed in `bridge_deps`. The consumer's own `bridge.js` (at repo root or `js/bridge.js`) is emitted last, so it can override symbols from deps. Each chunk is prefixed with a banner comment naming its origin.
+
+**Filename is fixed** (`bridge.js`). Listing a dep that has no such file will fail loudly when the build step runs — that is the correct behavior.
+
 ### Web API Coverage (built-in resolution)
 
 | Domain | Prefix | Examples |

--- a/build.zig
+++ b/build.zig
@@ -49,6 +49,13 @@ pub fn build(b: *std.Build) void {
 pub const InstallAppOptions = struct {
     port: u16 = 8080,
     output_dir: []const u8 = "dist",
+    /// Zig dependencies that ship a `bridge.js` at their package root. Each
+    /// listed dep must actually have a `bridge.js` file -- resolution is
+    /// lazy, so a typo or missing file fails loudly when the RunStep executes.
+    /// Order is preserved; earlier entries are emitted earlier in the merged
+    /// JS. The user project's own `bridge.js` (if any) is always emitted last
+    /// so it can override dep-provided symbols.
+    bridge_deps: []const *std.Build.Dependency = &.{},
 };
 
 pub fn installApp(
@@ -66,6 +73,10 @@ pub fn installApp(
     gen_cmd.addArtifactArg(user_exe);
     gen_cmd.addArg("--output-dir");
     gen_cmd.addArg(options.output_dir);
+    for (options.bridge_deps) |bd| {
+        gen_cmd.addArg("--bridge-dep");
+        gen_cmd.addFileArg(bd.path("bridge.js"));
+    }
     gen_cmd.setCwd(b.path("."));
     b.getInstallStep().dependOn(&gen_cmd.step);
 
@@ -78,6 +89,10 @@ pub fn installApp(
     serve_cmd.addArg(options.output_dir);
     serve_cmd.addArg("--port");
     serve_cmd.addArg(b.fmt("{d}", .{options.port}));
+    for (options.bridge_deps) |bd| {
+        serve_cmd.addArg("--bridge-dep");
+        serve_cmd.addFileArg(bd.path("bridge.js"));
+    }
     serve_cmd.setCwd(b.path("."));
     run_step.dependOn(&serve_cmd.step);
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .zunk,
-    .version = "0.2.1",
+    .version = "0.3.0",
     .fingerprint = 0x56e2cba64281ab82, // Changing this has security and trust implications.
     .minimum_zig_version = "0.16.0",
     .dependencies = .{

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -187,9 +187,9 @@ Full WebGPU bindings are implemented and working. The particle-life example uses
 - [ ] WebMIDI (musical instruments)
 - [ ] Gamepad API (beyond current basic support -- gamepad section exists in InputState but JS flush skips it)
 
-### 4.3 Library convention for bridge.js
+### 4.3 Library convention for bridge.js -- DONE
 
-Define and document the convention for Zig packages that ship browser-side JS. When a zunk user depends on a Zig package that includes a `bridge.js`, zunk should automatically discover and merge it.
+Zig packages ship a `bridge.js` at their package root. Consumers opt in via `zunk.installApp(..., .{ .bridge_deps = &.{ teak, ... } })`. Dep-provided chunks are merged in listed order; the consumer's own `bridge.js` (or `js/bridge.js`) is appended last so it can override. Each chunk is banner-commented with its origin. `--bridge-dep <path>` is the underlying repeatable CLI flag (installApp wires it up automatically).
 
 ### 4.4 Source maps
 

--- a/docs/plan-4.3-4.4-5.1.md
+++ b/docs/plan-4.3-4.4-5.1.md
@@ -1,0 +1,174 @@
+# Plan: bridge.js convention + source maps + HMR
+
+Scratchpad for three roadmap items. Implement in order, land each as its own PR.
+Source of truth for scope when context is lost. If you diverge from this doc,
+update it first.
+
+---
+
+## 4.3 -- bridge.js package convention (FIRST)
+
+### Problem
+
+Today only the user project's root `bridge.js` (or `js/bridge.js`) is picked up.
+A library like teak wants to ship its own JS without every consumer pasting it
+in. Filesystem scans of the Zig package cache are unsafe (can't tell what the
+user actually depends on). The Zig build system is the only authority on the
+dep graph, so the handoff must go through `build.zig`.
+
+### Design
+
+**User-side:** `zunk.installApp` gains a `bridge_deps: []const *std.Build.Dependency`
+field. The user lists deps that ship a `bridge.js`:
+
+```zig
+const zunk = b.dependency("zunk", .{});
+const teak = b.dependency("teak", .{});
+zunk.installApp(b, exe, .{ .bridge_deps = &.{ teak } });
+```
+
+**installApp:** for each dep, emits `--bridge-dep <lazy path>` using
+`gen_cmd.addFileArg(dep.path("bridge.js"))`. Zig's build system resolves lazy
+paths to real filesystem paths at run time, and fails loudly if the file is
+missing -- that is the correct behavior (a dep declared as bridge-carrying
+must actually carry one).
+
+**CLI:** `--bridge-dep <path>` is repeatable. Collected into a list. Still
+accept the existing project-root auto-discovery (`bridge.js`, `js/bridge.js`)
+for the user's own bridge.js.
+
+**Merge order in generated JS:**
+1. Dep bridges, in the order listed in `bridge_deps` (library layer first)
+2. User project's own bridge.js last (so user can override dep symbols)
+
+Each chunk is prefixed with a banner comment naming its origin:
+`// --- bridge.js from <origin-label> ---`. Origin label = file path for
+user, basename of dep package dir for deps (e.g. `teak`).
+
+**Types in js_gen:** `GenOptions.bridge_js: ?[]const u8` becomes
+`bridge_js_chunks: []const BridgeJsChunk` where
+`BridgeJsChunk = struct { origin: []const u8, source: []const u8 }`.
+Empty slice = no bridges. `generate` concatenates with banners.
+
+**Build cache fingerprint:** include mtimes of every `--bridge-dep` path, not
+just the user's bridge.js.
+
+**Docs:** add a section to README ("Shipping a bridge.js in a zunk library")
+explaining the filename convention (`bridge.js` at dep package root), how to
+wire it via `bridge_deps`, and the merge order / override precedence.
+
+### Out of scope for this PR
+
+- Auto-discovery by scanning the cache -- rejected (unsafe).
+- Multiple bridge files per dep.
+- Naming conflicts between deps (last write wins -- document, don't police).
+
+---
+
+## 4.4 -- source maps (SECOND)
+
+### Scope: name-section only, not DWARF
+
+The big win for teak developers is seeing real Zig function names in devtools
+stack traces instead of `wasm-function[1234]`. Chrome/Firefox already render
+WASM function names from the `name` custom section, so the generated JS
+doesn't strictly need a .js.map for *that*. What a .js.map gets us:
+
+- Mapping generated JS lines back to something meaningful when a JS-side
+  trampoline throws (it currently shows a line in `app-<hash>.js` with no
+  clue whether it's in a canvas wrapper or an audio wrapper).
+
+### Plan
+
+1. Track `{generated_line -> (source_tag, original_line)}` tuples while
+   writing the JS. `source_tag` = category string (`"canvas"`, `"audio"`,
+   `"webgpu"`, `"bridge:teak"`, `"runtime"`, etc.). Start coarse -- line per
+   emitted extern wrapper is enough.
+2. Emit a VLQ-encoded .js.map (Source Map v3) alongside `app-<hash>.js`.
+   Sources list is synthetic (`zunk://canvas.js`, `zunk://audio.js`, etc.),
+   each file contents = the concatenated lines tagged to that category, so
+   devtools has something to display when clicking through.
+3. Reference it via `//# sourceMappingURL=app-<hash>.js.map` at the tail of
+   the generated JS. In `deploy`, the map file gets its own content-hashed
+   filename.
+4. Serve `.js.map` with `application/json` MIME in `serve.zig`.
+
+### Out of scope
+
+- DWARF -> Zig source line numbers. Bigger project (parse WASM DWARF
+  sections, build line tables). Deferred. Mention in doc.
+- Mapping back to Zig for the *WASM* side -- browsers already handle this if
+  the WASM binary has a `name` section and DWARF sections (Zig leaves these
+  in by default except at ReleaseSmall).
+
+---
+
+## 5.1 -- HMR (THIRD)
+
+### Design sketch (MUST WRITE A `docs/hmr.md` BEFORE CODING)
+
+**Trigger:** existing WebSocket (`/__zunk_ws`) already broadcasts a `"reload"`
+message today. Add a `"hmr"` message type sent when only the WASM binary
+changed (JS scaffolding unchanged). If JS or HTML changed, fall back to full
+reload.
+
+**Runtime protocol (JS side):**
+1. Fetch new `.wasm` into an ArrayBuffer.
+2. Instantiate with the *same* imports object -- handle table, audio context,
+   WebGPU device, WebSocket connections all preserved.
+3. If old module exports `cleanup`, call it.
+4. If old module exports `serialize_model` and new module exports
+   `hydrate_model`, call `serialize_model()` on old (returns ptr+len into old
+   memory), copy bytes out into a JS Uint8Array, drop old memory, call
+   `hydrate_model(ptr, len)` on new module (after copying bytes into new
+   memory via shared exchange buffer).
+5. Else call `init` on new module.
+6. Resume the rAF loop against the new `frame` export.
+
+**Runtime protocol (Zig side, opt-in for teak):**
+- Teak adds `export fn serialize_model() [*]u8` / returns a length via a
+  paired export, OR writes into an agreed-upon exchange slot. Design this
+  more concretely in `docs/hmr.md`. Ideal ergonomics: `zunk.bind.exposeHmr`
+  helper that takes a `*Model` and a `SerializeFn`.
+
+**Constraints / gotchas:**
+- Old WASM memory holds the old Model, pointers into old memory are
+  invalidated after swap. serialize_model must produce a self-contained byte
+  blob (no pointers).
+- Callbacks registered on the old module (e.g. `requestAnimationFrame`
+  chained, audio buffer end) must be redirected to new module's exports.
+  Handle table entries keyed by function index need re-resolution: store
+  *export names* alongside indices so we can re-lookup after swap.
+- Bridge.js functions that closed over old `instance` references must take
+  the instance from a mutable module-level variable, not a closure capture.
+  Generated JS will need refactor: replace per-call closures with
+  `currentInstance` lookups.
+
+**Fallback:** if anything goes wrong (hydrate_model missing, memory corrupt,
+export signature changed), log to browser console and do a full reload. HMR
+is a DX nicety, never required for correctness.
+
+**Flag:** `--hmr` on `zunk run` (default off during stabilization, flip on by
+default once teak validates it).
+
+### Phases
+
+1. Write `docs/hmr.md` with full protocol before any code.
+2. Refactor generated JS to use module-level `currentInstance` instead of
+   closure capture.
+3. Add `"hmr"` WebSocket message + client handler (full reload fallback
+   baked in from day 1).
+4. Add Zig-side `zunk.bind.exposeHmr` helper + example wiring in the
+   imgui-demo example.
+5. Teak integrates and reports back.
+
+---
+
+## Cross-cutting conventions
+
+- Each PR has its own branch off master: `feat/bridge-deps`, `feat/sourcemaps`,
+  `feat/hmr`.
+- Version bump in `build.zig.zon` per PR (CI enforces this on master).
+- Examples must still build after each PR. particle-life + imgui-demo are
+  the canaries.
+- No deletions -- archive per CLAUDE.md rule 1.

--- a/src/gen/js_gen.zig
+++ b/src/gen/js_gen.zig
@@ -2,10 +2,19 @@ const std = @import("std");
 const wa = @import("wasm_analyze.zig");
 const resolver = @import("js_resolve.zig");
 
+pub const BridgeJsChunk = struct {
+    /// Human-readable label printed into the merged JS as a banner comment
+    /// (e.g. `bridge.js`, `js/bridge.js`, or a dep package directory name).
+    origin: []const u8,
+    source: []const u8,
+};
+
 pub const GenOptions = struct {
     public_url: []const u8 = "/",
     wasm_filename: []const u8,
-    bridge_js: ?[]const u8 = null,
+    /// Concatenated in order. Convention: dep-provided chunks first, user's
+    /// own project chunk last, so the user can override symbols from deps.
+    bridge_js_chunks: []const BridgeJsChunk = &.{},
     js_filename: []const u8 = "app.js",
     wasm_preload: bool = false,
     js_integrity: ?[]const u8 = null,
@@ -97,9 +106,9 @@ pub fn generate(
 
     try w.writeAll("};\n\n");
 
-    if (opts.bridge_js) |bridge| {
-        try w.writeAll("// --- bridge.js (library-provided) ---\n");
-        try w.writeAll(bridge);
+    for (opts.bridge_js_chunks) |chunk| {
+        try w.print("// --- bridge.js from {s} ---\n", .{chunk.origin});
+        try w.writeAll(chunk.source);
         try w.writeAll("\n\n");
     }
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -65,11 +65,14 @@ fn printUsage(console: *rich.Console) !void {
     try console.print("    [yellow]--port[/] <num>          Server port for 'run' (default: 8080)");
     try console.print("    [yellow]--no-watch[/]             Disable source watching for 'run'");
     try console.print("    [yellow]--proxy[/] <prefix=url>  Proxy requests (e.g. --proxy /api=http://localhost:3000)");
+    try console.print("    [yellow]--bridge-dep[/] <path>    Include a dep-provided bridge.js (repeatable; typically wired by installApp)");
     try console.print("    [yellow]--verbose[/] / [yellow]-v[/]        Show all resolutions in build report");
     try console.print("    [yellow]--report-json[/]          Output build report as JSON");
     try console.print("    [yellow]--force[/]                Bypass build cache");
     try console.print("");
 }
+
+const max_bridge_deps = 32;
 
 const BuildArgs = struct {
     wasm_path: ?[]const u8 = null,
@@ -80,6 +83,12 @@ const BuildArgs = struct {
     verbose: bool = false,
     json_report: bool = false,
     force: bool = false,
+    bridge_deps_buf: [max_bridge_deps][]const u8 = undefined,
+    bridge_deps_len: usize = 0,
+
+    fn bridgeDeps(self: *const BuildArgs) []const []const u8 {
+        return self.bridge_deps_buf[0..self.bridge_deps_len];
+    }
 };
 
 fn parseBuildArgs(args: []const []const u8) BuildArgs {
@@ -106,6 +115,12 @@ fn parseBuildArgs(args: []const []const u8) BuildArgs {
         } else if (std.mem.eql(u8, args[i], "--proxy") and i + 1 < args.len) {
             result.proxy = args[i + 1];
             i += 1;
+        } else if (std.mem.eql(u8, args[i], "--bridge-dep") and i + 1 < args.len) {
+            if (result.bridge_deps_len < max_bridge_deps) {
+                result.bridge_deps_buf[result.bridge_deps_len] = args[i + 1];
+                result.bridge_deps_len += 1;
+            }
+            i += 1;
         }
     }
     return result;
@@ -131,12 +146,16 @@ const BuildContext = struct {
     wasm: []const u8,
     analysis: wa.Analysis,
     wasm_basename: []const u8,
-    bridge_js: ?[]const u8,
+    bridge_chunks: []js_gen.BridgeJsChunk,
 
     fn deinit(self: *BuildContext, allocator: std.mem.Allocator) void {
         allocator.free(self.wasm);
         self.analysis.deinit(allocator);
-        if (self.bridge_js) |b| allocator.free(b);
+        for (self.bridge_chunks) |c| {
+            allocator.free(c.origin);
+            allocator.free(c.source);
+        }
+        allocator.free(self.bridge_chunks);
     }
 };
 
@@ -168,11 +187,20 @@ fn prepareBuild(allocator: std.mem.Allocator, io: std.Io, parsed: BuildArgs, con
     var analysis = try wa.analyze(allocator, wasm);
     errdefer analysis.deinit(allocator);
 
+    const bridge_chunks = try collectBridgeChunks(allocator, io, parsed.bridgeDeps(), console);
+    errdefer {
+        for (bridge_chunks) |c| {
+            allocator.free(c.origin);
+            allocator.free(c.source);
+        }
+        allocator.free(bridge_chunks);
+    }
+
     return .{
         .wasm = wasm,
         .analysis = analysis,
         .wasm_basename = std.Io.Dir.path.basename(wasm_path),
-        .bridge_js = discoverBridgeJs(allocator, io, console),
+        .bridge_chunks = bridge_chunks,
     };
 }
 
@@ -215,7 +243,7 @@ fn buildCommand(allocator: std.mem.Allocator, io: std.Io, args: []const []const 
     const parsed = parseBuildArgs(args);
 
     // Compute fingerprint once (used for both cache check and write)
-    const source_fp: ?i128 = if (parsed.wasm_path) |wasm_path| computeSourceFingerprint(io, wasm_path) else null;
+    const source_fp: ?i128 = if (parsed.wasm_path) |wasm_path| computeSourceFingerprint(io, wasm_path, parsed.bridgeDeps()) else null;
 
     // Cache check (non-serve mode only)
     if (!do_serve and !parsed.force) {
@@ -234,7 +262,7 @@ fn buildCommand(allocator: std.mem.Allocator, io: std.Io, args: []const []const 
 
     var result = try js_gen.generate(allocator, &ctx.analysis, .{
         .wasm_filename = ctx.wasm_basename,
-        .bridge_js = ctx.bridge_js,
+        .bridge_js_chunks = ctx.bridge_chunks,
         .verbose_report = parsed.verbose,
         .json_report = parsed.json_report,
     });
@@ -278,7 +306,7 @@ fn buildCommand(allocator: std.mem.Allocator, io: std.Io, args: []const []const 
 fn deployCommand(allocator: std.mem.Allocator, io: std.Io, args: []const []const u8, console: *rich.Console) !void {
     const parsed = parseBuildArgs(args);
 
-    const source_fp: ?i128 = if (parsed.wasm_path) |wasm_path| computeSourceFingerprint(io, wasm_path) else null;
+    const source_fp: ?i128 = if (parsed.wasm_path) |wasm_path| computeSourceFingerprint(io, wasm_path, parsed.bridgeDeps()) else null;
 
     if (!parsed.force) {
         if (source_fp) |fp| {
@@ -304,7 +332,7 @@ fn deployCommand(allocator: std.mem.Allocator, io: std.Io, args: []const []const
     // Generate JS (only needs hashed wasm name -- JS content is independent of its own filename)
     var result = try js_gen.generate(allocator, &ctx.analysis, .{
         .wasm_filename = hashed_wasm_name,
-        .bridge_js = ctx.bridge_js,
+        .bridge_js_chunks = ctx.bridge_chunks,
         .verbose_report = parsed.verbose,
         .json_report = parsed.json_report,
     });
@@ -323,7 +351,7 @@ fn deployCommand(allocator: std.mem.Allocator, io: std.Io, args: []const []const
     defer html_aw.deinit();
     try js_gen.generateHtml(&html_aw.writer, &ctx.analysis, .{
         .wasm_filename = hashed_wasm_name,
-        .bridge_js = ctx.bridge_js,
+        .bridge_js_chunks = ctx.bridge_chunks,
         .js_filename = hashed_js_name,
         .wasm_preload = true,
         .js_integrity = sri,
@@ -364,16 +392,73 @@ fn deployCommand(allocator: std.mem.Allocator, io: std.Io, args: []const []const
     }
 }
 
-fn discoverBridgeJs(allocator: std.mem.Allocator, io: std.Io, console: *rich.Console) ?[]const u8 {
-    for (bridge_js_paths) |path| {
-        if (std.Io.Dir.cwd().readFileAlloc(io, path, allocator, .limited(1 * 1024 * 1024))) |contents| {
-            var buf: [128]u8 = undefined;
-            const msg = std.fmt.bufPrint(&buf, "Found {s}", .{path}) catch "Found bridge.js";
-            console.printStyled(msg, rich.Style.empty.foreground(rich.Color.cyan)) catch {};
-            return contents;
-        } else |_| {}
+/// Derive a short human-readable label for a dep-provided bridge.js.
+/// Example: `.../zig-pkg/teak-0.1.0-HASH/bridge.js` -> `teak-0.1.0-HASH`.
+/// The label is only used for banner comments in the merged JS, so being
+/// verbose is fine -- debuggability > brevity.
+fn depBridgeOrigin(allocator: std.mem.Allocator, path: []const u8) ![]u8 {
+    const dir = std.Io.Dir.path.dirname(path) orelse return allocator.dupe(u8, path);
+    const base = std.Io.Dir.path.basename(dir);
+    if (base.len == 0) return allocator.dupe(u8, path);
+    return allocator.dupe(u8, base);
+}
+
+/// Builds the ordered list of bridge.js chunks passed to the generator.
+/// Order: every `--bridge-dep` path, in CLI order, followed by the first
+/// matching user project path (`bridge.js` then `js/bridge.js`). User-
+/// provided chunks come last so they can override dep-provided symbols.
+fn collectBridgeChunks(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    bridge_dep_paths: []const []const u8,
+    console: *rich.Console,
+) ![]js_gen.BridgeJsChunk {
+    var chunks: std.ArrayList(js_gen.BridgeJsChunk) = .empty;
+    errdefer {
+        for (chunks.items) |c| {
+            allocator.free(c.origin);
+            allocator.free(c.source);
+        }
+        chunks.deinit(allocator);
     }
-    return null;
+
+    // Dep-provided chunks first.
+    for (bridge_dep_paths) |dep_path| {
+        const source = std.Io.Dir.cwd().readFileAlloc(io, dep_path, allocator, .limited(1 * 1024 * 1024)) catch |err| {
+            var buf: [512]u8 = undefined;
+            const msg = std.fmt.bufPrint(&buf, "error: --bridge-dep '{s}' could not be read: {}", .{ dep_path, err }) catch "error: --bridge-dep unreadable";
+            console.printStyled(msg, rich.Style.empty.foreground(rich.Color.red)) catch {};
+            return error.BridgeDepMissing;
+        };
+        errdefer allocator.free(source);
+
+        const origin = try depBridgeOrigin(allocator, dep_path);
+        errdefer allocator.free(origin);
+
+        try chunks.append(allocator, .{ .origin = origin, .source = source });
+
+        var buf: [256]u8 = undefined;
+        const msg = std.fmt.bufPrint(&buf, "Found bridge.js from {s}", .{origin}) catch "Found dep bridge.js";
+        console.printStyled(msg, rich.Style.empty.foreground(rich.Color.cyan)) catch {};
+    }
+
+    // User project bridge.js (first matching path wins, appended last so it overrides deps).
+    for (bridge_js_paths) |path| {
+        const source = std.Io.Dir.cwd().readFileAlloc(io, path, allocator, .limited(1 * 1024 * 1024)) catch continue;
+        errdefer allocator.free(source);
+
+        const origin = try allocator.dupe(u8, path);
+        errdefer allocator.free(origin);
+
+        try chunks.append(allocator, .{ .origin = origin, .source = source });
+
+        var buf: [128]u8 = undefined;
+        const msg = std.fmt.bufPrint(&buf, "Found {s}", .{path}) catch "Found bridge.js";
+        console.printStyled(msg, rich.Style.empty.foreground(rich.Color.cyan)) catch {};
+        break;
+    }
+
+    return try chunks.toOwnedSlice(allocator);
 }
 
 fn copyAssets(allocator: std.mem.Allocator, io: std.Io, out_dir: std.Io.Dir, console: *rich.Console) void {
@@ -408,7 +493,7 @@ fn copyAssets(allocator: std.mem.Allocator, io: std.Io, out_dir: std.Io.Dir, con
 
 // --- Build caching ---
 
-fn computeSourceFingerprint(io: std.Io, wasm_path: []const u8) i128 {
+fn computeSourceFingerprint(io: std.Io, wasm_path: []const u8, bridge_dep_paths: []const []const u8) i128 {
     var fingerprint: i128 = 0;
 
     // src/ directory recursive mtime sum
@@ -431,8 +516,16 @@ fn computeSourceFingerprint(io: std.Io, wasm_path: []const u8) i128 {
         fingerprint +%= @intCast(stat.mtime.nanoseconds);
     }
 
-    // bridge.js (if present)
+    // user project bridge.js (if present)
     for (bridge_js_paths) |bp| {
+        const file = std.Io.Dir.cwd().openFile(io, bp, .{}) catch continue;
+        defer file.close(io);
+        const stat = file.stat(io) catch continue;
+        fingerprint +%= @intCast(stat.mtime.nanoseconds);
+    }
+
+    // dep-provided bridge.js files passed via --bridge-dep
+    for (bridge_dep_paths) |bp| {
         const file = std.Io.Dir.cwd().openFile(io, bp, .{}) catch continue;
         defer file.close(io);
         const stat = file.stat(io) catch continue;


### PR DESCRIPTION
## Summary

- Zig libraries can now ship a `bridge.js` at their package root. Consumers opt in via `zunk.installApp(..., .{ .bridge_deps = &.{ dep } })`.
- Dep-provided chunks are merged first (in listed order); the user's own `bridge.js` / `js/bridge.js` appends last so it can override dep-provided symbols. Each chunk is banner-commented with its origin.
- Underlying CLI contract: repeatable `--bridge-dep <path>`. `installApp` wires it via `dep.path("bridge.js")` + `addFileArg`, so a missing file fails loudly at step-run time (explicit and correct).
- Build cache fingerprint now includes dep bridge mtimes, so updating a library's `bridge.js` invalidates the cached build.
- Also lands `docs/plan-4.3-4.4-5.1.md` tracking the three-feature workstream (bridge convention + source maps + HMR); future items are 4.4 and 5.1.

Roadmap entry 4.3 flipped to DONE.

## Test plan

- [x] `zig build` clean
- [x] `zig build test` green
- [x] `imgui-demo` builds end-to-end
- [x] `particle-life` builds end-to-end
- [x] Manual: ran `zunk build --bridge-dep <fake>/bridge.js` + a user `bridge.js`, verified dep chunk emits first and user chunk appends last with correct origin banners in `dist/app.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)