### PR TITLE
Emit Source Map v3 for bridge.js chunks

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .zunk,
-    .version = "0.3.0",
+    .version = "0.4.0",
     .fingerprint = 0x56e2cba64281ab82, // Changing this has security and trust implications.
     .minimum_zig_version = "0.16.0",
     .dependencies = .{

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -191,9 +191,11 @@ Full WebGPU bindings are implemented and working. The particle-life example uses
 
 Zig packages ship a `bridge.js` at their package root. Consumers opt in via `zunk.installApp(..., .{ .bridge_deps = &.{ teak, ... } })`. Dep-provided chunks are merged in listed order; the consumer's own `bridge.js` (or `js/bridge.js`) is appended last so it can override. Each chunk is banner-commented with its origin. `--bridge-dep <path>` is the underlying repeatable CLI flag (installApp wires it up automatically).
 
-### 4.4 Source maps
+### 4.4 Source maps -- PARTIALLY DONE
 
-Generate source maps so developers can debug their Zig code in browser devtools. Map generated JS lines back to WASM function names, and ideally to Zig source locations via DWARF debug info in the WASM.
+**Done:** Source Map v3 emission covering bridge.js chunks. When the generated JS includes one or more `bridge.js` chunks (user-provided or from `bridge_deps`), zunk emits an `app.js.map` (or `app-<hash>.js.map` in deploy mode) that points those lines back at the original library source. Stack traces from a teak-style bridge.js land in readable code in devtools. SRI covers the final bytes (including `sourceMappingURL` trailer); served with `application/json` MIME.
+
+**Deferred:** DWARF -> Zig source line mapping (browsers already render WASM function names from the `name` custom section, so this is less urgent). Category-level sections (one source per Web API category like canvas / audio / webgpu) -- follow-up when the current bridge sections prove out.
 
 ### 4.5 WASM size optimization
 

--- a/docs/plan-4.3-4.4-5.1.md
+++ b/docs/plan-4.3-4.4-5.1.md
@@ -65,7 +65,12 @@ wire it via `bridge_deps`, and the merge order / override precedence.
 
 ---
 
-## 4.4 -- source maps (SECOND)
+## 4.4 -- source maps (SHIPPED in v0.4.0, bridge-section scope)
+
+Landed scope is narrower than what follows: v1 emits Source Map v3 with one
+source per bridge.js chunk only. No category-level sections, no DWARF. The
+teak-specific win (stack traces from library-provided bridge.js land in
+readable library code) is met. Category-level sectioning moves to a follow-up.
 
 ### Scope: name-section only, not DWARF
 

--- a/src/gen/js_gen.zig
+++ b/src/gen/js_gen.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const wa = @import("wasm_analyze.zig");
 const resolver = @import("js_resolve.zig");
+const source_map = @import("source_map.zig");
 
 pub const BridgeJsChunk = struct {
     /// Human-readable label printed into the merged JS as a banner comment
@@ -26,6 +27,10 @@ pub const Categories = std.enums.EnumSet(resolver.Category);
 
 pub const GenResult = struct {
     js: []const u8,
+    /// Source Map v3 JSON, or empty if no mappable content was emitted
+    /// (currently: empty when there are no bridge.js chunks). When empty,
+    /// callers should skip writing a .js.map file.
+    js_map: []const u8,
     html: []const u8,
     report: []const u8,
     js_hash: [16]u8,
@@ -33,6 +38,7 @@ pub const GenResult = struct {
 
     pub fn deinit(self: *GenResult, allocator: std.mem.Allocator) void {
         allocator.free(self.js);
+        if (self.js_map.len != 0) allocator.free(self.js_map);
         allocator.free(self.html);
         allocator.free(self.report);
     }
@@ -106,10 +112,25 @@ pub fn generate(
 
     try w.writeAll("};\n\n");
 
+    // Record byte spans of bridge.js content so the source map can point
+    // back at the original library-provided JS. Span is [start, end) and
+    // covers only the chunk body (not the banner comment or trailing
+    // padding).
+    var bridge_spans: std.ArrayList(source_map.Span) = .empty;
+    defer bridge_spans.deinit(allocator);
+
     for (opts.bridge_js_chunks) |chunk| {
         try w.print("// --- bridge.js from {s} ---\n", .{chunk.origin});
+        const start_byte = js_aw.written().len;
         try w.writeAll(chunk.source);
+        const end_byte = js_aw.written().len;
         try w.writeAll("\n\n");
+        try bridge_spans.append(allocator, .{
+            .source = chunk.origin,
+            .source_content = chunk.source,
+            .start_byte = start_byte,
+            .end_byte = end_byte,
+        });
     }
 
     try w.print(
@@ -208,6 +229,16 @@ pub fn generate(
 
     try w.writeAll("\n})();\n");
 
+    // Build the source map BEFORE the header rewrite below so byte offsets
+    // recorded in bridge_spans remain valid. The rewrite lengthens the
+    // header but adds no newlines, so line numbers would be stable either
+    // way -- but building here keeps the byte math unambiguous.
+    const js_map: []const u8 = if (bridge_spans.items.len == 0)
+        ""
+    else
+        try source_map.build(allocator, js_aw.written(), bridge_spans.items);
+    errdefer if (js_map.len != 0) allocator.free(js_map);
+
     const full_hash = std.hash.XxHash3.hash(0, js_aw.written());
     var fingerprint: [8]u8 = undefined;
     std.mem.writeInt(u64, &fingerprint, full_hash, .big);
@@ -236,6 +267,7 @@ pub fn generate(
 
     return .{
         .js = try js.toOwnedSlice(allocator),
+        .js_map = js_map,
         .html = try html_aw.toOwnedSlice(),
         .report = try report_aw.toOwnedSlice(),
         .js_hash = hex,

--- a/src/gen/serve.zig
+++ b/src/gen/serve.zig
@@ -500,6 +500,7 @@ fn mimeType(path: []const u8) []const u8 {
     if (std.mem.eql(u8, ext, ".wasm")) return "application/wasm";
     if (std.mem.eql(u8, ext, ".css")) return "text/css";
     if (std.mem.eql(u8, ext, ".json")) return "application/json";
+    if (std.mem.eql(u8, ext, ".map")) return "application/json";
     if (std.mem.eql(u8, ext, ".png")) return "image/png";
     if (std.mem.eql(u8, ext, ".wgsl")) return "text/wgsl";
     if (std.mem.eql(u8, ext, ".svg")) return "image/svg+xml";

--- a/src/gen/source_map.zig
+++ b/src/gen/source_map.zig
@@ -1,0 +1,260 @@
+const std = @import("std");
+
+/// Source Map v3 generator.
+///
+/// Current scope (v1): emit one source per bridge.js chunk. Lines of the
+/// generated JS that fall inside a chunk's span are mapped back to the
+/// chunk's original source text, so a stack trace from a library-provided
+/// bridge.js lands in readable code in devtools. Lines outside bridge spans
+/// are left unmapped; browsers fall back to showing the generated JS as-is
+/// for those regions, which is exactly what we want.
+///
+/// Category-level sections (one source per Web API category like canvas /
+/// audio / webgpu) are a planned follow-up.
+pub const Span = struct {
+    /// Label shown in devtools (e.g. the bridge chunk's origin).
+    source: []const u8,
+    /// Original source content inlined into sourcesContent[].
+    source_content: []const u8,
+    /// Byte offset in the generated JS where this span's content begins.
+    start_byte: usize,
+    /// Byte offset in the generated JS where this span's content ends
+    /// (exclusive). Must be >= start_byte.
+    end_byte: usize,
+};
+
+/// Build a Source Map v3 JSON document for the given generated JS.
+/// `spans` must be non-empty; caller handles the empty-map case (skip
+/// emitting a .js.map entirely).
+pub fn build(
+    allocator: std.mem.Allocator,
+    generated_js: []const u8,
+    spans: []const Span,
+) ![]const u8 {
+    std.debug.assert(spans.len > 0);
+
+    var aw: std.Io.Writer.Allocating = .init(allocator);
+    defer aw.deinit();
+    const w = &aw.writer;
+
+    try w.writeAll("{\"version\":3,\"sources\":[");
+    for (spans, 0..) |s, i| {
+        if (i > 0) try w.writeByte(',');
+        try w.writeByte('"');
+        try writeJsonEscaped(w, s.source);
+        try w.writeByte('"');
+    }
+    try w.writeAll("],\"sourcesContent\":[");
+    for (spans, 0..) |s, i| {
+        if (i > 0) try w.writeByte(',');
+        try w.writeByte('"');
+        try writeJsonEscaped(w, s.source_content);
+        try w.writeByte('"');
+    }
+    try w.writeAll("],\"mappings\":\"");
+    try writeMappings(w, generated_js, spans);
+    try w.writeAll("\"}");
+
+    return aw.toOwnedSlice();
+}
+
+/// Count how many output lines a span occupies. A span that doesn't end
+/// with '\n' still occupies a final partial line.
+fn countLines(text: []const u8) u32 {
+    if (text.len == 0) return 0;
+    var n: u32 = 0;
+    for (text) |c| if (c == '\n') {
+        n += 1;
+    };
+    if (text[text.len - 1] != '\n') n += 1;
+    return n;
+}
+
+fn byteOffsetToLine(text: []const u8, offset: usize) u32 {
+    var line: u32 = 0;
+    for (text[0..offset]) |c| if (c == '\n') {
+        line += 1;
+    };
+    return line;
+}
+
+const Section = struct {
+    source_index: u32,
+    start_line: u32,
+    /// exclusive
+    end_line: u32,
+};
+
+fn writeMappings(
+    w: *std.Io.Writer,
+    generated_js: []const u8,
+    spans: []const Span,
+) !void {
+    // Convert byte spans to line spans once, in source-index order.
+    var sections_buf: [64]Section = undefined;
+    std.debug.assert(spans.len <= sections_buf.len);
+    var sections = sections_buf[0..spans.len];
+
+    var total_lines: u32 = 0;
+    {
+        var i: usize = 0;
+        while (i < generated_js.len) : (i += 1) {
+            if (generated_js[i] == '\n') total_lines += 1;
+        }
+        // Trailing partial line without newline still counts.
+        if (generated_js.len > 0 and generated_js[generated_js.len - 1] != '\n') total_lines += 1;
+    }
+
+    for (spans, 0..) |s, i| {
+        const start = byteOffsetToLine(generated_js, s.start_byte);
+        const span_line_count = countLines(generated_js[s.start_byte..s.end_byte]);
+        sections[i] = .{
+            .source_index = @intCast(i),
+            .start_line = start,
+            .end_line = start + span_line_count,
+        };
+    }
+
+    // Emit mappings: one ';' between generated lines. For lines inside a
+    // section, emit a single VLQ segment mapping gen col 0 -> source N,
+    // relative line, col 0. For lines outside, emit nothing.
+    var last_source_idx: i32 = 0;
+    var last_src_line: i32 = 0;
+
+    var line: u32 = 0;
+    while (line < total_lines) : (line += 1) {
+        if (line > 0) try w.writeByte(';');
+
+        const section = findSection(sections, line) orelse continue;
+
+        const src_idx: i32 = @intCast(section.source_index);
+        const rel_src_line: i32 = @intCast(line - section.start_line);
+
+        // Segment values: [col_in_gen, src_idx_delta, src_line_delta, src_col_delta]
+        // col_in_gen is reset to 0 each line, so it's always 0.
+        // src_col is always 0 in our line-granularity mapping.
+        try encodeVlq(w, 0);
+        try encodeVlq(w, src_idx - last_source_idx);
+        try encodeVlq(w, rel_src_line - last_src_line);
+        try encodeVlq(w, 0);
+
+        last_source_idx = src_idx;
+        last_src_line = rel_src_line;
+    }
+}
+
+fn findSection(sections: []const Section, line: u32) ?*const Section {
+    for (sections) |*s| {
+        if (line >= s.start_line and line < s.end_line) return s;
+    }
+    return null;
+}
+
+const base64_chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+fn encodeVlq(w: *std.Io.Writer, value: i32) !void {
+    // Base64 VLQ (as specified by source map v3):
+    // - Sign goes in the LSB of the unsigned representation.
+    // - 5 data bits per base64 digit, continuation bit in the 6th.
+    var v: u32 = if (value < 0)
+        (@as(u32, @intCast(-value)) << 1) | 1
+    else
+        @as(u32, @intCast(value)) << 1;
+
+    while (true) {
+        var digit: u32 = v & 0b11111;
+        v >>= 5;
+        if (v != 0) digit |= 0b100000;
+        try w.writeByte(base64_chars[digit]);
+        if (v == 0) break;
+    }
+}
+
+fn writeJsonEscaped(w: *std.Io.Writer, s: []const u8) !void {
+    for (s) |c| {
+        switch (c) {
+            '"' => try w.writeAll("\\\""),
+            '\\' => try w.writeAll("\\\\"),
+            '\n' => try w.writeAll("\\n"),
+            '\r' => try w.writeAll("\\r"),
+            '\t' => try w.writeAll("\\t"),
+            0x08 => try w.writeAll("\\b"),
+            0x0C => try w.writeAll("\\f"),
+            else => if (c < 0x20) {
+                try w.print("\\u{x:0>4}", .{c});
+            } else {
+                try w.writeByte(c);
+            },
+        }
+    }
+}
+
+test "vlq zero" {
+    var buf: [8]u8 = undefined;
+    var fw: std.Io.Writer = .fixed(&buf);
+    try encodeVlq(&fw, 0);
+    try std.testing.expectEqualStrings("A", fw.buffered());
+}
+
+test "vlq positive small" {
+    var buf: [8]u8 = undefined;
+    var fw: std.Io.Writer = .fixed(&buf);
+    try encodeVlq(&fw, 1);
+    try std.testing.expectEqualStrings("C", fw.buffered());
+}
+
+test "vlq negative small" {
+    var buf: [8]u8 = undefined;
+    var fw: std.Io.Writer = .fixed(&buf);
+    try encodeVlq(&fw, -1);
+    try std.testing.expectEqualStrings("D", fw.buffered());
+}
+
+test "vlq positive multi-digit" {
+    // 16 -> bits 10000, shifted for sign = 100000 -> needs two digits.
+    // 16 << 1 = 32 = 0b100000. Low 5 bits = 0, cont bit set -> g.
+    // Then v = 1. Low 5 = 1, no cont -> B.
+    var buf: [8]u8 = undefined;
+    var fw: std.Io.Writer = .fixed(&buf);
+    try encodeVlq(&fw, 16);
+    try std.testing.expectEqualStrings("gB", fw.buffered());
+}
+
+test "countLines basic" {
+    try std.testing.expectEqual(@as(u32, 0), countLines(""));
+    try std.testing.expectEqual(@as(u32, 1), countLines("foo"));
+    try std.testing.expectEqual(@as(u32, 1), countLines("foo\n"));
+    try std.testing.expectEqual(@as(u32, 2), countLines("foo\nbar"));
+    try std.testing.expectEqual(@as(u32, 2), countLines("foo\nbar\n"));
+    try std.testing.expectEqual(@as(u32, 3), countLines("foo\nbar\n\n"));
+}
+
+test "build single-span map" {
+    const gpa = std.testing.allocator;
+    // Generated JS has a banner line, then two bridge lines, then a closing line.
+    const generated =
+        \\// runtime line 0
+        \\// --- bridge.js from teak ---
+        \\teakFn1();
+        \\teakFn2();
+        \\// runtime trailing
+    ;
+    // Bridge content (verbatim chunk source).
+    const bridge = "teakFn1();\nteakFn2();";
+    const bridge_start = std.mem.indexOf(u8, generated, bridge).?;
+    const bridge_end = bridge_start + bridge.len;
+
+    const json = try build(gpa, generated, &.{.{
+        .source = "teak/bridge.js",
+        .source_content = bridge,
+        .start_byte = bridge_start,
+        .end_byte = bridge_end,
+    }});
+    defer gpa.free(json);
+
+    // Must be valid JSON containing sources + sourcesContent + mappings.
+    try std.testing.expect(std.mem.indexOf(u8, json, "\"version\":3") != null);
+    try std.testing.expect(std.mem.indexOf(u8, json, "teak/bridge.js") != null);
+    try std.testing.expect(std.mem.indexOf(u8, json, "teakFn1") != null);
+    try std.testing.expect(std.mem.indexOf(u8, json, "\"mappings\":") != null);
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -272,7 +272,18 @@ fn buildCommand(allocator: std.mem.Allocator, io: std.Io, args: []const []const 
     defer out_dir.close(io);
 
     try out_dir.writeFile(io, .{ .sub_path = "index.html", .data = result.html });
-    try out_dir.writeFile(io, .{ .sub_path = "app.js", .data = result.js });
+
+    // JS + optional sourceMappingURL trailer + optional .js.map sidecar.
+    const final_js = if (result.js_map.len != 0)
+        try std.fmt.allocPrint(allocator, "{s}\n//# sourceMappingURL=app.js.map\n", .{result.js})
+    else
+        try allocator.dupe(u8, result.js);
+    defer allocator.free(final_js);
+    try out_dir.writeFile(io, .{ .sub_path = "app.js", .data = final_js });
+    if (result.js_map.len != 0) {
+        try out_dir.writeFile(io, .{ .sub_path = "app.js.map", .data = result.js_map });
+    }
+
     try out_dir.writeFile(io, .{ .sub_path = ctx.wasm_basename, .data = ctx.wasm });
 
     copyAssets(allocator, io, out_dir, console);
@@ -338,12 +349,24 @@ fn deployCommand(allocator: std.mem.Allocator, io: std.Io, args: []const []const
     });
     defer result.deinit(allocator);
 
-    // Content-hashed JS filename + SRI
+    // Content-hashed JS filename is derived from result.js BEFORE the
+    // sourceMappingURL trailer so the hash is stable regardless of map
+    // emission. SRI, however, must cover the exact bytes served, so it is
+    // computed against `final_js` below.
     const js_fp = contentFingerprint(result.js);
     const hashed_js_name = try std.fmt.allocPrint(allocator, "app-{s}.js", .{&js_fp});
     defer allocator.free(hashed_js_name);
 
-    const sri = try computeSri(result.js, allocator);
+    const hashed_map_name = try std.fmt.allocPrint(allocator, "{s}.map", .{hashed_js_name});
+    defer allocator.free(hashed_map_name);
+
+    const final_js = if (result.js_map.len != 0)
+        try std.fmt.allocPrint(allocator, "{s}\n//# sourceMappingURL={s}\n", .{ result.js, hashed_map_name })
+    else
+        try allocator.dupe(u8, result.js);
+    defer allocator.free(final_js);
+
+    const sri = try computeSri(final_js, allocator);
     defer allocator.free(sri);
 
     // Generate deploy HTML directly (avoids a redundant second full generation pass)
@@ -364,7 +387,10 @@ fn deployCommand(allocator: std.mem.Allocator, io: std.Io, args: []const []const
     defer out_dir.close(io);
 
     try out_dir.writeFile(io, .{ .sub_path = "index.html", .data = deploy_html });
-    try out_dir.writeFile(io, .{ .sub_path = hashed_js_name, .data = result.js });
+    try out_dir.writeFile(io, .{ .sub_path = hashed_js_name, .data = final_js });
+    if (result.js_map.len != 0) {
+        try out_dir.writeFile(io, .{ .sub_path = hashed_map_name, .data = result.js_map });
+    }
     try out_dir.writeFile(io, .{ .sub_path = hashed_wasm_name, .data = ctx.wasm });
 
     copyAssets(allocator, io, out_dir, console);
@@ -381,6 +407,10 @@ fn deployCommand(allocator: std.mem.Allocator, io: std.Io, args: []const []const
             try console.print(m1);
             const m2 = std.fmt.bufPrint(&pbuf, "  {s}/{s}", .{ parsed.output_dir, hashed_js_name }) catch "";
             try console.print(m2);
+            if (result.js_map.len != 0) {
+                const m_map = std.fmt.bufPrint(&pbuf, "  {s}/{s}", .{ parsed.output_dir, hashed_map_name }) catch "";
+                try console.print(m_map);
+            }
             const m3 = std.fmt.bufPrint(&pbuf, "  {s}/{s}", .{ parsed.output_dir, hashed_wasm_name }) catch "";
             try console.print(m3);
         }


### PR DESCRIPTION
## Summary

- Generated JS now ships an `app.js.map` sidecar (or `app-<hash>.js.map` in deploy mode) when one or more bridge.js chunks are present.
- Each bridge chunk becomes a named source in the map with its original contents inlined as `sourcesContent`. A stack trace landing in library-provided JS resolves to readable code in devtools, not a line buried in the concatenated `app.js`.
- New module `src/gen/source_map.zig` handles base64-VLQ encoding and Source Map v3 JSON assembly.
- `main.zig` appends `//# sourceMappingURL=...` to the final JS. Deploy mode hashes the JS without the trailer (stable filename), then recomputes SRI on the final bytes (including trailer) so the integrity check matches what the browser loads.
- `serve.zig` serves `.map` with `application/json`.

Scope is deliberately narrow: only bridge.js chunks get mappings. Category-level sections and DWARF -> Zig source line mapping are deferred (noted in ROADMAP + planning doc).

## Test plan

- [x] `zig build` clean
- [x] `zig build test` green (includes new VLQ + map-builder tests in `source_map.zig`)
- [x] `imgui-demo`, `particle-life`, `input-demo` all build end-to-end
- [x] Manual (build mode): ran `zunk build --bridge-dep <fake>/bridge.js`, verified `app.js` ends with `//# sourceMappingURL=app.js.map` and the emitted `app.js.map` parses as valid JSON with correct `sources` / `sourcesContent` / VLQ `mappings` (4 bridge lines -> `AAAA;AACA;AACA;AACA`)
- [x] Manual (deploy mode): ran `zunk deploy`, verified hashed `app-<hash>.js.map` is written and the SRI in `index.html` matches `sha384` of the final `app-<hash>.js` bytes
- [x] Manual (no-bridge case): verified no `.js.map` is written and no `sourceMappingURL` trailer is appended when no bridge chunks are present

🤖 Generated with [Claude Code](https://claude.com/claude-code)