### PR TITLE
v0.10.0: a11y DOM mirror + canvas readback flag (closes #13, #15)

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .zunk,
-    .version = "0.9.0",
+    .version = "0.10.0",
     .fingerprint = 0x56e2cba64281ab82, // Changing this has security and trust implications.
     .minimum_zig_version = "0.16.0",
     .dependencies = .{

--- a/docs/to_teak_team/v0.10.0-a11y-bridge.md
+++ b/docs/to_teak_team/v0.10.0-a11y-bridge.md
@@ -1,0 +1,131 @@
+# Zunk v0.10.0 -- A11y DOM mirror + canvas readback flag
+
+**Audience**: Teak maintainers.
+**Zunk version**: 0.10.0 (additive; no breaking changes).
+**Tracking**: closes <https://github.com/hotschmoe/zunk/issues/15> and
+<https://github.com/hotschmoe/zunk/issues/13>.
+
+## TL;DR
+
+Two web-target fixes Teak's `dev-hotschmoe` branch has been waiting on:
+
+1. `__zunk_publish_a11y_tree` is now resolved. The per-frame a11y
+   snapshot teak's `Host` ships out the extern is mirrored into a
+   hidden `#zunk-a11y-root` DOM subtree so NVDA/JAWS/VoiceOver can
+   announce widgets that are otherwise just pixels in the
+   wgpu-driven `<canvas>`. Pre-v0.10 builds: extern resolved away at
+   link time and the call was a no-op (per teak's `@hasDecl` gate),
+   so nothing breaks if Teak pins an older zunk.
+2. The offscreen text-rasterizer canvas now opts into
+   `willReadFrequently: true`. Chrome's perf warning during Teak's
+   first-paint glyph-cache misses (and continuous misses on dynamic
+   labels) goes away, and `getImageData` takes the software path
+   that the warning was telling us to use.
+
+Tag to pin once merged: **v0.10.0**.
+
+## Wiring summary (a11y)
+
+```
+teak host loop                 zunk JS shim                     browser DOM
+--------------                 ------------                     -----------
+buildA11yTree(arena, ...)
+serializeA11yTree(nodes)
+  -> g_a11y_records, g_a11y_strings
+externs.__zunk_publish_a11y_tree(
+  records_ptr, records_len,
+  strings_ptr, strings_len)
+                               lazy: create #zunk-a11y-root
+                                 (position:absolute; left:-9999px;
+                                  width:1px; height:1px; overflow:hidden)
+                               parse DataView (40 B stride, LE)
+                               diff against last frame's Map<cmd_index, el>
+                               role -> ARIA role + attrs:
+                                  button     -> <button> role=button tabindex=0
+                                  text_input -> <input>  role=textbox aria-multiline=false
+                                  checkbox   -> <div>    role=checkbox aria-checked
+                                  radio      -> <div>    role=radio    aria-checked
+                                  slider     -> <div>    role=slider   aria-valuenow
+                                  image      -> <img>    alt=label
+                                  overlay    -> <div>    role=dialog   aria-modal=true
+                                  text/rich  -> <div>    aria-label (no role)
+                                  group/scroll/divider -> mapped role, no extras
+                               adds/updates/removes children in place
+                                                                AT walks
+                                                                hidden tree
+```
+
+## What zunk now does
+
+- New exact-match entry in `gen/js_resolve.zig` for
+  `__zunk_publish_a11y_tree`. Resolves under a new `a11y` category so
+  feature gating stays narrow -- the preamble (state Map, ARIA / tag
+  lookup tables, lazy root container) is only emitted when a build
+  actually imports the extern.
+- New preamble in `gen/js_gen.zig` (`emitA11yState`) declares
+  `zunkA11yRoot`, `zunkA11yElements`, `zunkA11yAria`, `zunkA11yTags`
+  at module scope. Strict-mode-safe (everything is `let` / `const`),
+  zero allocations per frame in steady state once the DOM stabilizes.
+- Diff is keyed on `cmd_index` exactly as documented in the issue:
+  stable within a frame, comparable across frames as long as the Cmd
+  buffer shape hasn't changed. When the shape *does* change, mismatches
+  produce DOM thrash for one frame and then re-stabilize.
+- Role changes at the same `cmd_index` recreate the underlying tag
+  (e.g. `<button>` -> `<input>` when role flips from button to
+  text_input). Tracked via a hidden `el._zunkRole` slot to avoid a
+  re-read of DOM attributes.
+
+## What you DO NOT need to change
+
+- `extern "env" fn __zunk_publish_a11y_tree(...)` -- the 40-byte
+  record stride and the UTF-8 string heap match teak's `A11yRecord`
+  layout exactly. The JS shim's `DataView` offsets are the same
+  literals documented in `src/platform/wasm.zig`.
+- The `@hasDecl(externs, "__zunk_publish_a11y_tree")` gate in
+  `publishA11yTree`. Older zunks still link clean; this version
+  satisfies the extern so the gate flips on automatically.
+- The `MAX_A11Y_NODES = 256` / 8 KB heap caps. The shim trusts the
+  wire format and does no extra bounds validation -- if a record
+  claims a label past the heap, the JS would read garbage, but the
+  Zig side already guards against that.
+
+## willReadFrequently
+
+Same lazy block in both `measure_text` and `rasterize_text`:
+
+```js
+zunkTextCtx = zunkTextCanvas.getContext('2d', { willReadFrequently: true });
+```
+
+No API change, no Zig-side delta. The warning disappears on the next
+`zig build web` against zunk 0.10.
+
+## Out of scope (still)
+
+- Hit-testing parity. The hidden container uses off-screen positioning
+  (`left:-9999px`) so children are not visually positioned at canvas
+  pixel coordinates. If a focus-management story ever needs the AT to
+  see "real" positions, swap to `opacity: 0` over the canvas without
+  a wire-format change.
+- Reading `aria-pressed` / `aria-expanded` (button states beyond
+  focused) -- add bits to `A11yRecord.flags` first, then add cases to
+  the shim's `switch (role)`.
+- Live-region announcements (`aria-live=polite`). Today the shim is
+  pure structure mirroring; transient notifications would need a
+  parallel "announce this string" path.
+
+## Smoke test
+
+```
+cd examples/a11y-demo
+zig build
+zunk run
+```
+
+Open devtools, inspect `#zunk-a11y-root`. You should see five
+children (a button, a checkbox, a slider, a text node, and an image
+that cycles in / out every 60 frames). The slider's `aria-valuenow`
+ticks each frame; the checkbox's `aria-checked` flips every 120
+frames. With NVDA/VoiceOver running, tabbing into the page announces
+"Open, button". The canvas itself stays opaque to AT -- only the
+mirror is announced.

--- a/examples/a11y-demo/build.zig
+++ b/examples/a11y-demo/build.zig
@@ -1,0 +1,39 @@
+const std = @import("std");
+const zunk = @import("zunk");
+
+pub fn build(b: *std.Build) void {
+    const optimize = b.option(
+        std.builtin.OptimizeMode,
+        "optimize",
+        "Optimization mode (default: ReleaseFast)",
+    ) orelse .ReleaseFast;
+
+    const wasm_target = b.resolveTargetQuery(.{
+        .cpu_arch = .wasm32,
+        .os_tag = .freestanding,
+        .abi = .none,
+    });
+
+    const zunk_dep = b.dependency("zunk", .{
+        .target = wasm_target,
+        .optimize = optimize,
+    });
+
+    const exe = b.addExecutable(.{
+        .name = "a11y-demo",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/main.zig"),
+            .target = wasm_target,
+            .optimize = optimize,
+            .imports = &.{
+                .{ .name = "zunk", .module = zunk_dep.module("zunk") },
+            },
+        }),
+    });
+
+    exe.rdynamic = true;
+    exe.entry = .disabled;
+    exe.export_memory = true;
+
+    zunk.installApp(b, zunk_dep, exe, .{});
+}

--- a/examples/a11y-demo/build.zig.zon
+++ b/examples/a11y-demo/build.zig.zon
@@ -1,0 +1,14 @@
+.{
+    .name = .a11y_demo,
+    .version = "0.0.0",
+    .fingerprint = 0x8b0a78e304f579dd,
+    .minimum_zig_version = "0.16.0",
+    .dependencies = .{
+        .zunk = .{ .path = "../.." },
+    },
+    .paths = .{
+        "build.zig",
+        "build.zig.zon",
+        "src",
+    },
+}

--- a/examples/a11y-demo/src/main.zig
+++ b/examples/a11y-demo/src/main.zig
@@ -1,0 +1,162 @@
+/// A11y DOM-mirror smoke test for zunk GitHub issue #15.
+///
+/// Drives the same `__zunk_publish_a11y_tree` extern teak's `Host`
+/// calls each frame, with a hand-built record array. Verifies that:
+///   * The hidden `#zunk-a11y-root` container gets created lazily.
+///   * Records of each role (button, checkbox, slider, ...) produce
+///     DOM children with the correct ARIA mapping.
+///   * Stable cmd_index across frames reuses the same DOM nodes
+///     instead of rebuilding them; changing a role at the same
+///     cmd_index recreates the underlying tag (div -> button etc.).
+///   * Dropping a cmd_index between frames removes its DOM node.
+///
+/// Wire format mirrors teak's `A11yRecord` exactly (see
+/// `src/platform/wasm.zig` in the teak repo). Keep this in sync if
+/// the wire format ever changes -- the JS shim depends on the same
+/// 40-byte stride.
+const std = @import("std");
+const zunk = @import("zunk");
+const canvas = zunk.web.canvas;
+const input = zunk.web.input;
+const app = zunk.web.app;
+
+extern "env" fn __zunk_publish_a11y_tree(
+    records_ptr: [*]const u8,
+    records_len: u32,
+    strings_ptr: [*]const u8,
+    strings_len: u32,
+) void;
+
+const A11yRecord = extern struct {
+    cmd_index: u32,
+    role: u32,
+    label_offset: u32,
+    label_len: u32,
+    bounds_x: i32,
+    bounds_y: i32,
+    bounds_w: i32,
+    bounds_h: i32,
+    state: f32,
+    flags: u32,
+};
+
+comptime {
+    if (@sizeOf(A11yRecord) != 40) @compileError("A11yRecord size drifted from wire format");
+}
+
+const Role = enum(u32) {
+    group = 0,
+    scroll = 1,
+    text = 2,
+    rich_text = 3,
+    button = 4,
+    text_input = 5,
+    checkbox = 6,
+    radio = 7,
+    slider = 8,
+    divider = 9,
+    image = 10,
+    overlay = 11,
+};
+
+var records: [8]A11yRecord = undefined;
+var strings: [256]u8 = undefined;
+var ctx: canvas.Ctx2D = undefined;
+var frame_count: u32 = 0;
+var slider_value: f32 = 0.0;
+var checkbox_on: bool = false;
+
+const bg = canvas.Color{ .r = 17, .g = 17, .b = 22 };
+const white = canvas.Color{ .r = 220, .g = 220, .b = 220 };
+const dim = canvas.Color{ .r = 110, .g = 110, .b = 120 };
+
+export fn init() void {
+    input.init();
+    ctx = canvas.getContext2D("app");
+    app.setTitle("zunk a11y-demo");
+    canvas.setFont(ctx, "14px monospace");
+}
+
+export fn frame(_: f32) void {
+    input.poll();
+
+    // Tick a few values so the JS-side diff has something to update
+    // each frame (aria-valuenow on the slider, aria-checked on the
+    // checkbox). Demonstrates that the shim updates attributes in place
+    // instead of rebuilding nodes.
+    frame_count +%= 1;
+    slider_value = @as(f32, @floatFromInt(frame_count % 240)) / 240.0;
+    if (frame_count % 120 == 0) checkbox_on = !checkbox_on;
+
+    publishTree();
+    draw();
+}
+
+export fn resize(w: u32, h: u32) void {
+    canvas.setSize(ctx, w, h);
+}
+
+fn publishTree() void {
+    var strings_used: u32 = 0;
+    var count: usize = 0;
+
+    count = appendNode(count, &strings_used, 1, .button, "Open", 0);
+    count = appendNode(count, &strings_used, 2, .checkbox, "Enable feature", if (checkbox_on) 1.0 else 0.0);
+    count = appendNode(count, &strings_used, 3, .slider, "Volume", slider_value);
+    count = appendNode(count, &strings_used, 4, .text, "Hello, screen reader.", 0);
+    // Cycle a fifth node in/out every 60 frames to exercise add/remove
+    // diffing on the JS side.
+    if ((frame_count / 60) % 2 == 0) {
+        count = appendNode(count, &strings_used, 5, .image, "Decorative image", 0);
+    }
+
+    const records_bytes: u32 = @intCast(count * @sizeOf(A11yRecord));
+    const records_ptr: [*]const u8 = @ptrCast(&records);
+    __zunk_publish_a11y_tree(records_ptr, records_bytes, &strings, strings_used);
+}
+
+fn appendNode(
+    count: usize,
+    strings_used: *u32,
+    cmd_index: u32,
+    role: Role,
+    label: []const u8,
+    state: f32,
+) usize {
+    const label_offset = strings_used.*;
+    const label_len: u32 = @intCast(label.len);
+    @memcpy(strings[label_offset..][0..label.len], label);
+    strings_used.* += label_len;
+
+    records[count] = .{
+        .cmd_index = cmd_index,
+        .role = @intFromEnum(role),
+        .label_offset = label_offset,
+        .label_len = label_len,
+        .bounds_x = 0,
+        .bounds_y = 0,
+        .bounds_w = 0,
+        .bounds_h = 0,
+        .state = state,
+        .flags = 0,
+    };
+    return count + 1;
+}
+
+fn draw() void {
+    const vp = input.getViewportSize();
+    const w: f32 = @floatFromInt(vp.w);
+    const h: f32 = @floatFromInt(vp.h);
+
+    canvas.setFillColor(ctx, bg);
+    canvas.fillRect(ctx, 0, 0, w, h);
+
+    canvas.setFillColor(ctx, white);
+    canvas.setFont(ctx, "22px monospace");
+    canvas.fillText(ctx, "zunk a11y demo", 40, 50);
+
+    canvas.setFont(ctx, "13px monospace");
+    canvas.setFillColor(ctx, dim);
+    canvas.fillText(ctx, "open devtools, inspect #zunk-a11y-root, watch attrs update", 40, 76);
+    canvas.fillText(ctx, "screen readers see the mirror; canvas pixels stay opaque to them", 40, 96);
+}

--- a/src/gen/js_gen.zig
+++ b/src/gen/js_gen.zig
@@ -83,6 +83,7 @@ pub fn generate(
     if (categories_used.contains(.audio)) needs.audio_state = true;
     if (categories_used.contains(.webgpu)) needs.webgpu_init = true;
     if (categories_used.contains(.ui)) needs.ui_system = true;
+    if (categories_used.contains(.a11y)) needs.a11y_state = true;
 
     var js_aw: std.Io.Writer.Allocating = .init(allocator);
     defer js_aw.deinit();
@@ -100,6 +101,7 @@ pub fn generate(
     if (needs.webgpu_init) try emitWebGPUState(w);
     if (categories_used.contains(.fetch)) try w.writeAll("let zunkFetchBuf = null;\n\n");
     if (needs.ui_system) try emitUISystem(w);
+    if (needs.a11y_state) try emitA11yState(w);
 
     // Mutable WASM bindings. Held at module scope so that HMR can swap the
     // underlying instance while env methods (which close over this scope
@@ -303,6 +305,7 @@ const Features = struct {
     audio_state: bool = false,
     webgpu_init: bool = false,
     ui_system: bool = false,
+    a11y_state: bool = false,
 };
 
 /// Generate the `__zunkHmrSwap(wasmUrl)` function and expose it on
@@ -493,6 +496,23 @@ fn emitWebGPUState(w: *std.Io.Writer) !void {
         \\let zunkGPUFormat = null;
         \\let zunkTextCanvas = null;
         \\let zunkTextCtx = null;
+        \\
+        \\
+    );
+}
+
+fn emitA11yState(w: *std.Io.Writer) !void {
+    // Hidden DOM subtree for screen-reader announcement of canvas-rendered
+    // widgets. Root container is created lazily inside the shim on first
+    // publish; the per-cmd_index element Map lives across frames so the
+    // diff can add/update/remove elements without rebuilding from scratch.
+    // Role tag indexes match teak's `a11y.Role` enum order (see issue #15).
+    try w.writeAll(
+        \\// --- A11y DOM mirror state ---
+        \\let zunkA11yRoot = null;
+        \\const zunkA11yElements = new Map();
+        \\const zunkA11yAria = ['group','region',null,null,'button','textbox','checkbox','radio','slider','separator','img','dialog'];
+        \\const zunkA11yTags = ['div','div','div','div','button','input','div','div','div','div','img','div'];
         \\
         \\
     );

--- a/src/gen/js_resolve.zig
+++ b/src/gen/js_resolve.zig
@@ -55,6 +55,8 @@ pub const Category = enum {
     clipboard,
     // UI
     ui,
+    // Accessibility (hidden DOM mirror for screen readers)
+    a11y,
     // Application
     lifecycle,
     timer,
@@ -155,6 +157,43 @@ pub const exact_db = [_]ExactEntry{
         "let p;try{p=mode===0?window.showOpenFilePicker(opts):window.showSaveFilePicker(opts);}catch(e){console.warn('[zunk] file picker threw synchronously:',e);done(null);return;}" ++
         "p.then(r=>{const h=Array.isArray(r)?r[0]:r;const bytes=new TextEncoder().encode(h.name);const ptr=exports.__zunk_string_buf_ptr();const cap=exports.__zunk_string_buf_len();const len=Math.min(bytes.length,cap);new Uint8Array(memory.buffer,ptr,len).set(bytes.subarray(0,len));done([ptr,len]);})" ++
         ".catch(()=>{done(null);});", .needs_strings = true, .needs_memory = true, .category = .dom, .desc = "Browser file picker (open/save); resolves async via __zunk_file_dialog_result" },
+
+    // A11y DOM mirror for Teak (see zunk GitHub issue #15). Wasm calls
+    // `__zunk_publish_a11y_tree(records*, records_len, strings*, strings_len)`
+    // once per frame with the current snapshot of interactive widgets.
+    // Buffers live in wasm linear memory; both are stable for the duration
+    // of the call only. The JS shim mirrors the tree into a hidden DOM
+    // subtree so AT (NVDA/JAWS/VoiceOver) can announce widgets that are
+    // otherwise just pixels in a wgpu-driven canvas. See
+    // `docs/to_teak_team/v0.10.0-a11y-bridge.md` for the wire format.
+    .{ .name = "__zunk_publish_a11y_tree", .js = "const rptr=arguments[0],rlen=arguments[1],sptr=arguments[2],slen=arguments[3];" ++
+        "if(!zunkA11yRoot){zunkA11yRoot=document.createElement('div');zunkA11yRoot.id='zunk-a11y-root';zunkA11yRoot.style.cssText='position:absolute;left:-9999px;top:0;width:1px;height:1px;overflow:hidden;';document.body.appendChild(zunkA11yRoot);}" ++
+        "const dv=new DataView(memory.buffer,rptr,rlen);" ++
+        "const seen=new Set();" ++
+        "const count=(rlen/40)|0;" ++
+        "for(let i=0;i<count;i++){" ++
+            "const off=i*40;" ++
+            "const cmd=dv.getUint32(off,true),role=dv.getUint32(off+4,true);" ++
+            "const lof=dv.getUint32(off+8,true),llen=dv.getUint32(off+12,true);" ++
+            "const state=dv.getFloat32(off+32,true),flags=dv.getUint32(off+36,true);" ++
+            "if(role>11)continue;" ++
+            "const label=llen?readStr(sptr+lof,llen):'';" ++
+            "seen.add(cmd);" ++
+            "let el=zunkA11yElements.get(cmd);" ++
+            "if(!el||el._zunkRole!==role){if(el)el.remove();el=document.createElement(zunkA11yTags[role]);el._zunkRole=role;zunkA11yElements.set(cmd,el);zunkA11yRoot.appendChild(el);}" ++
+            "const aria=zunkA11yAria[role];" ++
+            "if(aria)el.setAttribute('role',aria);else el.removeAttribute('role');" ++
+            "if(llen)el.setAttribute('aria-label',label);else el.removeAttribute('aria-label');" ++
+            "switch(role){" ++
+                "case 4:el.tabIndex=0;if(flags&1)el.setAttribute('data-focused','');else el.removeAttribute('data-focused');break;" ++
+                "case 5:el.setAttribute('aria-multiline','false');break;" ++
+                "case 6:case 7:el.setAttribute('aria-checked',state>=0.5?'true':'false');break;" ++
+                "case 8:el.setAttribute('aria-valuenow',String(state));el.setAttribute('aria-valuemin','0');el.setAttribute('aria-valuemax','1');break;" ++
+                "case 10:if(llen)el.alt=label;break;" ++
+                "case 11:el.setAttribute('aria-modal','true');break;" ++
+            "}" ++
+        "}" ++
+        "zunkA11yElements.forEach((el,key)=>{if(!seen.has(key)){el.remove();zunkA11yElements.delete(key);}});", .needs_strings = true, .needs_memory = true, .category = .a11y, .desc = "Mirror Teak's per-frame a11y tree into a hidden DOM subtree for screen readers" },
 };
 
 fn exactMatch(allocator: std.mem.Allocator, name: []const u8) ?Resolution {

--- a/src/gen/js_resolve.zig
+++ b/src/gen/js_resolve.zig
@@ -172,26 +172,26 @@ pub const exact_db = [_]ExactEntry{
         "const seen=new Set();" ++
         "const count=(rlen/40)|0;" ++
         "for(let i=0;i<count;i++){" ++
-            "const off=i*40;" ++
-            "const cmd=dv.getUint32(off,true),role=dv.getUint32(off+4,true);" ++
-            "const lof=dv.getUint32(off+8,true),llen=dv.getUint32(off+12,true);" ++
-            "const state=dv.getFloat32(off+32,true),flags=dv.getUint32(off+36,true);" ++
-            "if(role>11)continue;" ++
-            "const label=llen?readStr(sptr+lof,llen):'';" ++
-            "seen.add(cmd);" ++
-            "let el=zunkA11yElements.get(cmd);" ++
-            "if(!el||el._zunkRole!==role){if(el)el.remove();el=document.createElement(zunkA11yTags[role]);el._zunkRole=role;zunkA11yElements.set(cmd,el);zunkA11yRoot.appendChild(el);}" ++
-            "const aria=zunkA11yAria[role];" ++
-            "if(aria)el.setAttribute('role',aria);else el.removeAttribute('role');" ++
-            "if(llen)el.setAttribute('aria-label',label);else el.removeAttribute('aria-label');" ++
-            "switch(role){" ++
-                "case 4:el.tabIndex=0;if(flags&1)el.setAttribute('data-focused','');else el.removeAttribute('data-focused');break;" ++
-                "case 5:el.setAttribute('aria-multiline','false');break;" ++
-                "case 6:case 7:el.setAttribute('aria-checked',state>=0.5?'true':'false');break;" ++
-                "case 8:el.setAttribute('aria-valuenow',String(state));el.setAttribute('aria-valuemin','0');el.setAttribute('aria-valuemax','1');break;" ++
-                "case 10:if(llen)el.alt=label;break;" ++
-                "case 11:el.setAttribute('aria-modal','true');break;" ++
-            "}" ++
+        "const off=i*40;" ++
+        "const cmd=dv.getUint32(off,true),role=dv.getUint32(off+4,true);" ++
+        "const lof=dv.getUint32(off+8,true),llen=dv.getUint32(off+12,true);" ++
+        "const state=dv.getFloat32(off+32,true),flags=dv.getUint32(off+36,true);" ++
+        "if(role>11)continue;" ++
+        "const label=llen?readStr(sptr+lof,llen):'';" ++
+        "seen.add(cmd);" ++
+        "let el=zunkA11yElements.get(cmd);" ++
+        "if(!el||el._zunkRole!==role){if(el)el.remove();el=document.createElement(zunkA11yTags[role]);el._zunkRole=role;zunkA11yElements.set(cmd,el);zunkA11yRoot.appendChild(el);}" ++
+        "const aria=zunkA11yAria[role];" ++
+        "if(aria)el.setAttribute('role',aria);else el.removeAttribute('role');" ++
+        "if(llen)el.setAttribute('aria-label',label);else el.removeAttribute('aria-label');" ++
+        "switch(role){" ++
+        "case 4:el.tabIndex=0;if(flags&1)el.setAttribute('data-focused','');else el.removeAttribute('data-focused');break;" ++
+        "case 5:el.setAttribute('aria-multiline','false');break;" ++
+        "case 6:case 7:el.setAttribute('aria-checked',state>=0.5?'true':'false');break;" ++
+        "case 8:el.setAttribute('aria-valuenow',String(state));el.setAttribute('aria-valuemin','0');el.setAttribute('aria-valuemax','1');break;" ++
+        "case 10:if(llen)el.alt=label;break;" ++
+        "case 11:el.setAttribute('aria-modal','true');break;" ++
+        "}" ++
         "}" ++
         "zunkA11yElements.forEach((el,key)=>{if(!seen.has(key)){el.remove();zunkA11yElements.delete(key);}});", .needs_strings = true, .needs_memory = true, .category = .a11y, .desc = "Mirror Teak's per-frame a11y tree into a hidden DOM subtree for screen readers" },
 };

--- a/src/gen/js_resolve.zig
+++ b/src/gen/js_resolve.zig
@@ -577,7 +577,7 @@ fn genWebGPU(allocator: std.mem.Allocator, method: []const u8, sig: ?wa.FuncType
         // Text-to-texture (workstream 2). Uses an offscreen <canvas> 2D
         // context to shape and rasterize text via the browser's built-in
         // text engine, then uploads the pixels into a GPUTexture.
-        .{ "measure_text", "if(!zunkTextCanvas){zunkTextCanvas=document.createElement('canvas');zunkTextCtx=zunkTextCanvas.getContext('2d');}" ++
+        .{ "measure_text", "if(!zunkTextCanvas){zunkTextCanvas=document.createElement('canvas');zunkTextCtx=zunkTextCanvas.getContext('2d',{willReadFrequently:true});}" ++
             "const text=readStr(arguments[0],arguments[1]),font=readStr(arguments[2],arguments[3]);" ++
             "zunkTextCtx.font=font;const m=zunkTextCtx.measureText(text);" ++
             "const w=Math.max(1,Math.ceil(m.width));" ++
@@ -585,7 +585,7 @@ fn genWebGPU(allocator: std.mem.Allocator, method: []const u8, sig: ?wa.FuncType
             "const dv=new DataView(memory.buffer,arguments[4],8);" ++
             "dv.setUint32(0,w,true);dv.setUint32(4,h,true);", false, true, true },
 
-        .{ "rasterize_text", "if(!zunkTextCanvas){zunkTextCanvas=document.createElement('canvas');zunkTextCtx=zunkTextCanvas.getContext('2d');}" ++
+        .{ "rasterize_text", "if(!zunkTextCanvas){zunkTextCanvas=document.createElement('canvas');zunkTextCtx=zunkTextCanvas.getContext('2d',{willReadFrequently:true});}" ++
             "const text=readStr(arguments[0],arguments[1]),font=readStr(arguments[2],arguments[3]);" ++
             "const r=arguments[4],g=arguments[5],b=arguments[6],a=arguments[7];" ++
             "const w=arguments[8],h=arguments[9];" ++


### PR DESCRIPTION
## Summary

- **#15** (a11y DOM mirror): Resolve `__zunk_publish_a11y_tree` into a hidden `#zunk-a11y-root` subtree so NVDA/JAWS/VoiceOver can announce widgets that are otherwise just pixels in a wgpu-driven `<canvas>`. New `a11y` Category gates a strict-mode-safe preamble (state Map + ARIA / tag lookup tables) so non-a11y builds skip the emit entirely.
- **#13** (`willReadFrequently`): Both lazy-init paths for `zunkTextCanvas` now pass `{willReadFrequently:true}` to `getContext('2d')`, silencing Chrome's perf warning on Teak's glyph-cache misses.
- **v0.10.0 ship**: `build.zig.zon` bumped, `docs/to_teak_team/v0.10.0-a11y-bridge.md` handoff note added covering both fixes.
- **`examples/a11y-demo/`**: hand-builds the same wire format teak's `serializeA11yTree` produces (with a comptime `@sizeOf` assert pinning the integration contract); cycles a node in/out every 60 frames and ticks `aria-valuenow`/`aria-checked` to exercise both add/remove diffing and in-place attribute updates.

Both changes are additive on zunk's side: pre-v0.10 builds had `__zunk_publish_a11y_tree` resolve away at link time via teak's `@hasDecl` gate, and `willReadFrequently` is just a `getContext` option -- no Zig-side delta, no ABI change. No breaking-version bump warranted.

## Test plan

- [x] `zig build` clean from root
- [x] `zig build test` clean from root
- [x] `examples/a11y-demo/` builds; resolver report shows `a11y: 1` category
- [x] `examples/text-demo/` rebuilt -- generated `app.js` contains 2x `willReadFrequently` (both `measure_text` and `rasterize_text` paths)
- [x] `examples/text-demo/` generated `app.js` has zero `zunkA11y*` references (gating verified)
- [x] Generated JS parses cleanly (`bun build --target=browser`)
- [ ] Manual: open `examples/a11y-demo/` in a browser, inspect `#zunk-a11y-root`, watch `aria-valuenow` tick and the 5th node cycle every 60 frames
- [ ] Manual: NVDA/VoiceOver announces "Open, button" when tabbing into the page

🤖 Generated with [Claude Code](https://claude.com/claude-code)